### PR TITLE
Fix API fetch via proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@angular/platform-server": "20.0.0",
         "@angular/router": "20.0.0",
         "@angular/ssr": "20.0.0",
+        "https-proxy-agent": "7.0.6",
+        "node-fetch": "^3.3.2",
         "rxjs": "7.8.1",
         "tslib": "2.6.2",
         "zone.js": "0.15.1"
@@ -5235,7 +5237,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -6864,11 +6865,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7795,6 +7804,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7907,6 +7939,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -8367,7 +8411,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -9744,7 +9787,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
@@ -9880,6 +9922,44 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -13069,6 +13149,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/webpack": {
       "version": "5.99.8",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@angular/platform-server": "20.0.0",
     "@angular/router": "20.0.0",
     "@angular/ssr": "20.0.0",
+    "https-proxy-agent": "7.0.6",
     "node-fetch": "^3.3.2",
     "rxjs": "7.8.1",
     "tslib": "2.6.2",

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
 import 'zone.js/node';
 import express, { Request, Response } from 'express';
 import fetch from 'node-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { APP_BASE_HREF } from '@angular/common';
@@ -12,11 +13,16 @@ const distFolder = join(process.cwd(), 'dist/ssr-api-app/browser');
 const indexHtml = existsSync(join(distFolder, 'index.html')) ? readFileSync(join(distFolder, 'index.html')).toString() : '';
 
 app.get('/api/data', async (_req: Request, res: Response) => {
+  const proxyUrl = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+  const agent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : undefined;
   try {
-    const response = await fetch('https://jsonplaceholder.typicode.com/posts/1');
+    const response = await fetch('https://jsonplaceholder.typicode.com/posts/1', {
+      agent,
+    });
     const data = await response.json();
     res.json(data);
-  } catch {
+  } catch (err) {
+    console.error('Error fetching data:', err);
     res.status(500).send('Error');
   }
 });


### PR DESCRIPTION
## Summary
- add https-proxy-agent dependency
- use HttpsProxyAgent when fetching to support environments with HTTP(S)_PROXY

## Testing
- `npm run build:ssr`
- `node dist/ssr-api-app/server/main.js &`
- `curl -i http://localhost:4000/api/data`

------
https://chatgpt.com/codex/tasks/task_e_6840659303e0832ebe118c2856bd2344